### PR TITLE
Fixes to LookupForDate

### DIFF
--- a/lib/TaxCloud/Request/LookupForDate.php
+++ b/lib/TaxCloud/Request/LookupForDate.php
@@ -26,6 +26,7 @@
 
 namespace TaxCloud\Request;
 
+use TaxCloud\Address;
 use TaxCloud\Request\RequestBase;
 
 class LookupForDate extends RequestBase

--- a/lib/TaxCloud/Request/LookupForDate.php
+++ b/lib/TaxCloud/Request/LookupForDate.php
@@ -43,6 +43,7 @@ class LookupForDate extends RequestBase
   public function __construct($apiLoginID, $apiKey, $customerID, $cartID, $cartItems, $origin, $destination, $deliveredBySeller, $exemptCert, $useDate)
   {
     $this->setCustomerID($customerID);
+    $this->setCartID($cartID);
     $this->setCartItems($cartItems);
     $this->setOrigin($origin);
     $this->setDestination($destination);


### PR DESCRIPTION
As is Address resolves to the current namespace `TaxCloud\Request\Address` which doesn't exist. Adding a use to the proper address namespace `TaxCloud\Address`.